### PR TITLE
Use button as link instead of internal link

### DIFF
--- a/src/lib/components/PostCard.svelte
+++ b/src/lib/components/PostCard.svelte
@@ -14,7 +14,7 @@
 		<Card title={post.title} image="/img/{post.banner}" subTitle="{currentDate} door {post.author}">
 			{post.excerpt}
 			<p slot="bottom">
-				<Button><a href={post.slug}>Lees verder...</a></Button>
+				<Button isLink="true" href={post.slug}>Lees verder...</Button>
 			</p>
 		</Card>
 	</div>


### PR DESCRIPTION
Currently, the link to an individual blog post is only inside the button, whereas the button component supports these as properties. This PR switches the a to a button with href