### PR TITLE
Traffic snapshot

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"js.implicitProjectConfig.checkJs": true
+}

--- a/src/leaflet.legend.css
+++ b/src/leaflet.legend.css
@@ -1,0 +1,84 @@
+/* Courtesy of https://github.com/ptma/Leaflet.Legend */
+.leaflet-legend {
+	background-color: white;
+}
+
+.leaflet-legend-title {
+	margin: 3px;
+	padding-bottom: 5px;
+}
+
+.leaflet-legend-column {
+	float: left;
+	margin-left: 10px;
+}
+
+.leaflet-legend-item {
+	display: table;
+	margin: 2px 0;
+}
+
+.leaflet-legend-item span {
+	vertical-align: middle;
+	display: table-cell;
+	word-break: keep-all;
+	white-space: nowrap;
+	background-color: transparent;
+	text-align: left;
+}
+
+.leaflet-legend-item-clickable {
+	cursor: pointer;
+}
+
+.leaflet-legend-item-inactive span {
+	color: #cccccc;
+}
+
+.leaflet-legend-item-inactive i img,
+.leaflet-legend-item-inactive i canvas {
+	opacity: 0.3;
+	/*
+    color: #000000;
+    -webkit-filter: grayscale(100%);
+    -moz-filter: grayscale(100%);
+    -ms-filter: grayscale(100%);
+    -o-filter: grayscale(100%);
+    filter: grayscale(100%);
+    filter: gray;
+    */
+}
+
+.leaflet-legend-item i {
+	display: inline-block;
+	padding: 0px 3px 0px 4px;
+	position: relative;
+	vertical-align: middle;
+}
+
+.leaflet-legend-toggle {
+	background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBzdGFuZGFsb25lPSJubyI/PjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+PHN2ZyB0PSIxNTk5MDE0Mjk2NTEwIiBjbGFzcz0iaWNvbiIgdmlld0JveD0iMCAwIDEwMjQgMTAyNCIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHAtaWQ9IjE3Nzk4IiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ij48ZGVmcz48c3R5bGUgdHlwZT0idGV4dC9jc3MiPjwvc3R5bGU+PC9kZWZzPjxwYXRoIGQ9Ik05MzQuNCA0NzguNzJINzM3LjI4Yy0xNS44NzItMTEwLjA4LTExMS4xMDQtMTk0LjU2LTIyNS4yOC0xOTQuNTZTMzAyLjU5MiAzNjguNjQgMjg2LjcyIDQ3OC43Mkg4OS42djY2LjU2SDI4Ni43MmMxNS44NzIgMTEwLjA4IDExMS4xMDQgMTk0LjU2IDIyNS4yOCAxOTQuNTZzMjA5LjQwOC04NC40OCAyMjUuMjgtMTk0LjU2aDE5Ny4xMnYtNjYuNTZ6IiBmaWxsPSIjNzA3MDcwIiBwLWlkPSIxNzc5OSI+PC9wYXRoPjwvc3ZnPg==');
+	background-repeat: no-repeat;
+	background-position: 50% 50%;
+	box-shadow: none;
+	border-radius: 4px;
+}
+
+.leaflet-legend-contents {
+	display: none;
+}
+
+.leaflet-legend-expanded .leaflet-legend-contents {
+	display: block;
+	padding: 6px 15px 6px 6px;
+}
+
+.leaflet-legend-contents img {
+	position: absolute;
+}
+
+.leaflet-legend-contents:after {
+	content: '';
+	display: block;
+	clear: both;
+}

--- a/src/leaflet.legend.js
+++ b/src/leaflet.legend.js
@@ -1,0 +1,356 @@
+/* Courtesy of https://github.com/ptma/Leaflet.Legend */
+(function (factory, window) {
+	// define an AMD module that relies on 'leaflet'
+	if (typeof define === 'function' && define.amd) {
+		define(['leaflet'], factory);
+
+		// define a Common JS module that relies on 'leaflet'
+	} else if (typeof exports === 'object') {
+		module.exports = factory(require('leaflet'));
+	}
+
+	// attach your plugin to the global 'L' variable
+	if (typeof window !== 'undefined' && window.L) {
+		factory(L);
+	}
+})(function (L) {
+	class LegendSymbol {
+		constructor(control, container, legend) {
+			this._control = control;
+			this._container = container;
+			this._legend = legend;
+			this._width = this._control.options.symbolWidth;
+			this._height = this._control.options.symbolHeight;
+		}
+	}
+
+	class GeometricSymbol extends LegendSymbol {
+		constructor(control, container, legend) {
+			super(control, container, legend);
+
+			this._canvas = this._buildCanvas();
+			if (this._drawSymbol) {
+				this._drawSymbol();
+			}
+			this._style();
+		}
+
+		_buildCanvas() {
+			var canvas = L.DomUtil.create('canvas', null, this._container);
+			canvas.height = this._control.options.symbolHeight;
+			canvas.width = this._control.options.symbolWidth;
+			return canvas;
+		}
+
+		_drawSymbol() {}
+
+		_style() {
+			var ctx = (this._ctx = this._canvas.getContext('2d'));
+			if (this._legend.fill || this._legend.fillColor) {
+				ctx.globalAlpha = this._legend.fillOpacity || 1;
+				ctx.fillStyle = this._legend.fillColor || this._legend.color;
+				ctx.fill(this._legend.fillRule || 'evenodd');
+			}
+
+			if (this._legend.stroke || this._legend.color) {
+				if (this._legend.dashArray) {
+					ctx.setLineDash(this._legend.dashArray || []);
+				}
+				ctx.globalAlpha = this._legend.opacity || 1.0;
+				ctx.lineWidth = this._legend.weight || 2;
+				ctx.strokeStyle = this._legend.color || '#3388ff';
+				ctx.lineCap = this._legend.lineCap || 'round';
+				ctx.lineJoin = this._legend.lineJoin || 'round';
+				ctx.stroke();
+			}
+		}
+
+		rescale() {}
+
+		center() {}
+	}
+
+	class CircleSymbol extends GeometricSymbol {
+		_drawSymbol() {
+			var ctx = (this._ctx = this._canvas.getContext('2d'));
+
+			var legend = this._legend;
+			var linelWeight = legend.weight || 3;
+
+			var centerX = this._control.options.symbolWidth / 2;
+			var centerY = this._control.options.symbolHeight / 2;
+			var maxRadius = Math.min(centerX, centerY) - linelWeight;
+			var radius = maxRadius;
+			if (legend.radius) {
+				radius = Math.min(legend.radius, maxRadius);
+			}
+
+			ctx.arc(centerX, centerY, radius, 0, Math.PI * 2, false);
+		}
+	}
+
+	class PolylineSymbol extends GeometricSymbol {
+		_drawSymbol() {
+			var ctx = (this._ctx = this._canvas.getContext('2d'));
+
+			var x1 = 0;
+			var x2 = this._control.options.symbolWidth;
+			var y = this._control.options.symbolHeight / 2;
+
+			ctx.beginPath();
+			ctx.moveTo(x1, y);
+			ctx.lineTo(x2, y);
+		}
+	}
+
+	class RectangleSymbol extends GeometricSymbol {
+		_drawSymbol() {
+			var ctx = (this._ctx = this._canvas.getContext('2d'));
+			var linelWeight = this._legend.weight || 3;
+
+			var x0 = this._control.options.symbolWidth / 2;
+			var y0 = this._control.options.symbolHeight / 2;
+
+			var rx = x0 - linelWeight;
+			var ry = y0 - linelWeight;
+			if (rx == ry) {
+				ry = ry / 2;
+			}
+			ctx.rect(x0 - rx, y0 - ry, rx * 2, ry * 2);
+		}
+	}
+
+	/**
+	 * 圆心坐标：(x0,y0) 半径：r 角度(X轴顺时针旋转)：a
+	 * 弧度 = 角度 * Math.PI / 180
+	 * 则圆上任一点为：（x1,y1）
+	 * x1   =   x0   +   r   *   Math.cos( a  * Math.PI / 180)
+	 * y1   =   y0   +   r   *   Math.sin( a  * Math.PI / 180)
+	 */
+	class PolygonSymbol extends GeometricSymbol {
+		_drawSymbol() {
+			var ctx = (this._ctx = this._canvas.getContext('2d'));
+
+			var linelWeight = this._legend.weight || 3;
+			var x0 = this._control.options.symbolWidth / 2;
+			var y0 = this._control.options.symbolHeight / 2;
+			var r = Math.min(x0, y0) - linelWeight;
+			var a = 360 / this._legend.sides;
+			ctx.beginPath();
+			for (var i = 0; i <= this._legend.sides; i++) {
+				var x1 = x0 + r * Math.cos(((a * i + (90 - a / 2)) * Math.PI) / 180);
+				var y1 = y0 + r * Math.sin(((a * i + (90 - a / 2)) * Math.PI) / 180);
+				if (i == 0) {
+					ctx.moveTo(x1, y1);
+				} else {
+					ctx.lineTo(x1, y1);
+				}
+			}
+		}
+	}
+
+	class ImageSymbol extends LegendSymbol {
+		constructor(control, container, legend) {
+			super(control, container, legend);
+			this._img = null;
+			this._loadImages();
+		}
+
+		_loadImages() {
+			var imageLoaded = () => {
+				this.rescale();
+			};
+			var img = L.DomUtil.create('img', null, this._container);
+			this._img = img;
+			img.onload = imageLoaded;
+			img.src = this._legend.url;
+		}
+
+		rescale() {
+			if (this._img) {
+				var _options = this._control.options;
+				if (this._img.width > _options.symbolWidth || this._img.height > _options.symbolHeight) {
+					var imgW = this._img.width;
+					var imgH = this._img.height;
+					var scaleW = _options.symbolWidth / imgW;
+					var scaleH = _options.symbolHeight / imgH;
+					var scale = Math.min(scaleW, scaleH);
+					this._img.width = imgW * scale;
+					this._img.height = imgH * scale;
+				}
+				this.center();
+			}
+		}
+
+		center() {
+			var containerCenterX = this._container.offsetWidth / 2;
+			var containerCenterY = this._container.offsetHeight / 2;
+			var imageCenterX = parseInt(this._img.width) / 2;
+			var imageCenterY = parseInt(this._img.height) / 2;
+
+			var shiftX = containerCenterX - imageCenterX;
+			var shiftY = containerCenterY - imageCenterY;
+
+			this._img.style.left = shiftX.toString() + 'px';
+			this._img.style.top = shiftY.toString() + 'px';
+		}
+	}
+
+	L.Control.Legend = L.Control.extend({
+		options: {
+			position: 'topleft',
+			title: 'Legend',
+			legends: [],
+			symbolWidth: 24,
+			symbolHeight: 24,
+			opacity: 1.0,
+			column: 1,
+			collapsed: false
+		},
+
+		initialize: function (options) {
+			L.Util.setOptions(this, options);
+			this._legendSymbols = [];
+			this._buildContainer();
+		},
+
+		onAdd: function (map) {
+			this._map = map;
+			this._initLayout();
+			return this._container;
+		},
+
+		_buildContainer: function () {
+			this._container = L.DomUtil.create('div', 'leaflet-legend leaflet-bar leaflet-control');
+			this._container.style.backgroundColor = 'rgba(255,255,255, ' + this.options.opacity + ')';
+
+			this._contents = L.DomUtil.create('section', 'leaflet-legend-contents', this._container);
+			this._link = L.DomUtil.create('a', 'leaflet-legend-toggle', this._container);
+			this._link.title = 'Legend';
+			this._link.href = '#';
+
+			var title = L.DomUtil.create('h5', 'leaflet-legend-title', this._contents);
+			title.innerText = this.options.title || 'Legend';
+
+			var len = this.options.legends.length;
+			var colSize = Math.ceil(len / this.options.column);
+			var legendContainer = this._contents;
+			for (var i = 0; i < len; i++) {
+				if (i % colSize == 0) {
+					legendContainer = L.DomUtil.create('div', 'leaflet-legend-column', this._contents);
+				}
+				var legend = this.options.legends[i];
+				this._buildLegendItems(legendContainer, legend);
+			}
+		},
+
+		_buildLegendItems: function (legendContainer, legend) {
+			var legendItemDiv = L.DomUtil.create('div', 'leaflet-legend-item', legendContainer);
+			if (legend.inactive) {
+				L.DomUtil.addClass(legendItemDiv, 'leaflet-legend-item-inactive');
+			}
+			var symbolContainer = L.DomUtil.create('i', null, legendItemDiv);
+
+			var legendSymbol;
+			if (legend.type === 'image') {
+				legendSymbol = new ImageSymbol(this, symbolContainer, legend);
+			} else if (legend.type === 'circle') {
+				legendSymbol = new CircleSymbol(this, symbolContainer, legend);
+			} else if (legend.type === 'rectangle') {
+				legendSymbol = new RectangleSymbol(this, symbolContainer, legend);
+			} else if (legend.type === 'polygon') {
+				legendSymbol = new PolygonSymbol(this, symbolContainer, legend);
+			} else if (legend.type === 'polyline') {
+				legendSymbol = new PolylineSymbol(this, symbolContainer, legend);
+			} else {
+				L.DomUtil.remove(legendItemDiv);
+				return;
+			}
+			this._legendSymbols.push(legendSymbol);
+
+			symbolContainer.style.width = this.options.symbolWidth + 'px';
+			symbolContainer.style.height = this.options.symbolHeight + 'px';
+
+			var legendLabel = L.DomUtil.create('span', null, legendItemDiv);
+			legendLabel.style.paddingLeft = '10px';
+			legendLabel.innerText = legend.label;
+			if (legend.layers) {
+				L.DomUtil.addClass(legendItemDiv, 'leaflet-legend-item-clickable');
+				L.DomEvent.on(
+					legendItemDiv,
+					'click',
+					function () {
+						this._toggleLegend.call(this, legendItemDiv, legend.layers);
+					},
+					this
+				);
+			}
+		},
+
+		_initLayout: function () {
+			L.DomEvent.disableClickPropagation(this._container);
+			L.DomEvent.disableScrollPropagation(this._container);
+
+			if (this.options.collapsed) {
+				this._map.on('click', this.collapse, this);
+
+				L.DomEvent.on(
+					this._container,
+					{
+						mouseenter: this.expand,
+						mouseleave: this.collapse
+					},
+					this
+				);
+			} else {
+				this.expand();
+			}
+		},
+
+		_toggleLegend: function (legendDiv, layers) {
+			if (L.DomUtil.hasClass(legendDiv, 'leaflet-legend-item-inactive')) {
+				L.DomUtil.removeClass(legendDiv, 'leaflet-legend-item-inactive');
+				if (L.Util.isArray(layers)) {
+					for (var i = 0, len = layers.length; i < len; i++) {
+						this._map.addLayer(layers[i]);
+					}
+				} else {
+					this._map.addLayer(layers);
+				}
+			} else {
+				L.DomUtil.addClass(legendDiv, 'leaflet-legend-item-inactive');
+				if (L.Util.isArray(layers)) {
+					for (var i = 0, len = layers.length; i < len; i++) {
+						this._map.removeLayer(layers[i]);
+					}
+				} else {
+					this._map.removeLayer(layers);
+				}
+			}
+		},
+
+		expand: function () {
+			this._link.style.display = 'none';
+			L.DomUtil.addClass(this._container, 'leaflet-legend-expanded');
+			for (var legendSymbol of this._legendSymbols) {
+				legendSymbol.rescale();
+			}
+			return this;
+		},
+
+		collapse: function () {
+			this._link.style.display = 'block';
+			L.DomUtil.removeClass(this._container, 'leaflet-legend-expanded');
+			return this;
+		},
+
+		redraw: function () {
+			L.DomUtil.empty(this._contents);
+			this._buildLegendItems();
+		}
+	});
+
+	L.control.legend = L.control.Legend = function (options) {
+		return new L.Control.Legend(options);
+	};
+}, window);

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -29,14 +29,16 @@
 			}
 			let legendEntries = [];
 			const legendEntry = (label, color) => ({
-					label,
-					type: "rectangle",
-					color,
-					fillColor: color,
-					weight: 2
-				});
+				label,
+				type: 'rectangle',
+				color,
+				fillColor: color,
+				weight: 2
+			});
 			if (mt.name === MetricEnum.NONE.name) {
-				legendEntries = Object.entries(defaultColors).filter(([k,]) => k !== ErrorSegmentState).map(([k, v]) => (legendEntry(k, v.color)))
+				legendEntries = Object.entries(defaultColors)
+					.filter(([k]) => k !== ErrorSegmentState)
+					.map(([k, v]) => legendEntry(k, v.color));
 			} else if (mt.decreasing) {
 				let prevValue;
 				legendEntries = mt.colormap.map(({ value, color }) => {
@@ -44,7 +46,10 @@
 					if (prevValue === undefined) {
 						returnValue = legendEntry(`waarde > ${value}${mt.metricUnit}`, color);
 					} else {
-						returnValue = legendEntry(`${prevValue}${mt.metricUnit} > waarde > ${value}${mt.metricUnit}`, color);
+						returnValue = legendEntry(
+							`${prevValue}${mt.metricUnit} > waarde > ${value}${mt.metricUnit}`,
+							color
+						);
 					}
 					prevValue = value;
 					return returnValue;
@@ -56,15 +61,18 @@
 					if (prevValue === undefined) {
 						returnValue = legendEntry(`waarde < ${value}${mt.metricUnit}`, color);
 					} else {
-						returnValue = legendEntry(`${prevValue}${mt.metricUnit} < waarde < ${value}${mt.metricUnit}`, color);
+						returnValue = legendEntry(
+							`${prevValue}${mt.metricUnit} < waarde < ${value}${mt.metricUnit}`,
+							color
+						);
 					}
 					prevValue = value;
 					return returnValue;
 				});
 			}
 			legendControl = leaflet.control.Legend({
-				position: "bottomleft",
-				title: "Legende",
+				position: 'bottomleft',
+				title: 'Legende',
 				collapsed: false,
 				symbolWidth: 24,
 				opacity: 1,

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { SegmentStateEnum, MetricEnum } from '../../types';
+	import { colorFeatureMetric } from '../../utils';
 	import { onMount } from 'svelte';
 	import { browser } from '$app/env';
 	import MapPopup from './MapPopup.svelte';
@@ -111,25 +112,12 @@
 				return { ...streetStyle, color: '#3cb371' };
 		}
 	}
-	function styleFeatureMetric(feature, mt) {
-		switch (feature.properties.metrics?.[mt.name].rank) {
-			case 1:
-				return { ...streetStyle, color: '#3cb371' };
-			case 2:
-				return { ...streetStyle, color: '#ffa500' };
-			default:
-				if (isNaN(feature.properties.metrics?.[mt.name].rank)) {
-					return { ...streetStyle, color: '#808080' };
-				} else {
-					return { ...streetStyle, color: '#ff0000' };
-				}
-		}
-	}
+
 	function styleFeature(feature, mt) {
 		if (mt.name === MetricEnum.NONE.name) {
 			return styleFeatureNone(feature);
 		}
-		return styleFeatureMetric(feature, mt);
+		return { ...streetStyle, color: colorFeatureMetric(feature, mt) };
 	}
 
 	onMount(async () => {

--- a/src/lib/components/MapPopup.svelte
+++ b/src/lib/components/MapPopup.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { Badge } from 'spaper';
 	import { MetricEnum, SegmentStateEnum } from '../../types';
+	import { colorFeatureMetric } from '../../utils';
 
 	export let properties;
 	let previousDateString = properties.dateStart ?? properties.date;
@@ -21,7 +22,24 @@
 	const previousHourNum = new Date(Date.parse(previousDateString)).getHours();
 	const isMetric = properties.metric.name !== MetricEnum.NONE.name;
 	const showSpeedLimit = properties.metric.showSpeedLimit;
-	const isNotWorking = isMetric && isNaN(properties.metrics?.[properties.metric.name]?.rank);
+	const isNotWorking = isMetric && isNaN(properties.metrics?.[properties.metric.name]?.value);
+	let backgroundColor;
+	if (isNotWorking) {
+		// gray
+		backgroundColor = '#808080';
+	} else if (isMetric) {
+		backgroundColor = colorFeatureMetric({ properties }, properties.metric);
+	} else if (properties.state === SegmentStateEnum.INACTIVE) {
+		// red
+		backgroundColor = 'ff0000';
+	} else if (properties.state === SegmentStateEnum.NEW) {
+		// orange
+		backgroundColor = '#ffa500';
+	} else {
+		// green
+		backgroundColor = '#3cb371';
+	}
+	const style = `background-color=${backgroundColor}`;
 	const isInactive =
 		properties.state === SegmentStateEnum.INACTIVE ||
 		(isMetric &&
@@ -36,8 +54,6 @@
 		isMetric &&
 		!isNaN(properties.metrics?.[properties.metric.name]?.rank) &&
 		properties.metrics[properties.metric.name].rank === 1;
-	// const isInactive = properties.state === SegmentStateEnum.INACTIVE;
-	// const isNew = properties.state === SegmentStateEnum.NEW;
 
 	const isDefault = !isInactive && !isNew;
 	$: currentDate = currentDateStr === 'Invalid Date' ? '-' : currentDateStr;
@@ -48,10 +64,7 @@
 
 <div
 	class="border padding-left-small padding-right-small shadow shadow-small"
-	class:popup-not-working={isNotWorking}
-	class:popup-inactive-worst={isInactive}
-	class:popup-new-medium={isNew}
-	class:popup={isDefault}
+	style="background-color: {backgroundColor}"
 >
 	<h4>{properties.name}</h4>
 	<h5 class="child-borders">
@@ -63,9 +76,9 @@
 		{/if}
 		{#if isDefault && !isFirst && !isNotWorking}
 			Snelheidslimiet: {properties.speed_limit} km/u<br />
-			Hier zijn tussen {currentDate}
-			{currentHour} uur<br /> en {previousDate}
-			{previousHour} uur<br />
+			Hier zijn tussen {previousDate}
+			{previousHour} uur<br /> en {currentDate}
+			{currentHour} uur<br />
 			<Badge type="primary">
 				{Math.round(properties.pedestrian)}
 				<svg
@@ -147,9 +160,9 @@
 			{properties.metrics[properties.metric.name].rank}e<br />
 			met {Math.round(properties.metrics[properties.metric.name].value * 100) / 100}
 			{properties.metric.metricName}<br />
-			tussen {currentDate}
-			{currentHour} uur<br /> en {previousDate}
-			{previousHour} uur
+			tussen {previousDate}
+			{previousHour} uur<br /> en {currentDate}
+			{currentHour} uur
 		{/if}
 		{#if isMetric && isNotWorking}
 			{properties.state}<br />
@@ -159,33 +172,3 @@
 	</h5>
 	<a href="https://telraam.net/nl/location/{properties.segment_id}">Toon me meer data...</a>
 </div>
-
-<style>
-	.popup {
-		background-color: #3cb371;
-	}
-
-	.popup-inactive-worst {
-		background-color: #ff0000;
-	}
-
-	.popup-new-medium {
-		background-color: #ffa500;
-	}
-
-	.popup-not-working {
-		background-color: #808080;
-	}
-
-	.popup a {
-		color: #383838;
-		text-decoration: none;
-		background-image: none;
-	}
-
-	.popup a:hover {
-		color: #383838;
-		text-decoration: underline;
-		background-image: none;
-	}
-</style>

--- a/src/lib/components/MapPopup.svelte
+++ b/src/lib/components/MapPopup.svelte
@@ -18,8 +18,9 @@
 	const currentDateStr = new Date(Date.parse(currentDateString)).toLocaleString('nl-BE', options);
 	const currentHourNum = new Date(Date.parse(currentDateString)).getHours();
 	const previousDateStr = new Date(Date.parse(previousDateString)).toLocaleString('nl-BE', options);
-	const previousHourNum = new Date(Date.parse(previousDateStr)).getHours();
+	const previousHourNum = new Date(Date.parse(previousDateString)).getHours();
 	const isMetric = properties.metric.name !== MetricEnum.NONE.name;
+	const showSpeedLimit = properties.metric.showSpeedLimit;
 	const isNotWorking = isMetric && isNaN(properties.metrics?.[properties.metric.name]?.rank);
 	const isInactive =
 		properties.state === SegmentStateEnum.INACTIVE ||
@@ -57,8 +58,11 @@
 		{#if !isMetric}
 			{properties.state}<br />
 		{/if}
+		{#if isMetric && showSpeedLimit}
+			Snelheidslimiet: {properties.speed_limit} km/u<br />
+		{/if}
 		{#if isDefault && !isFirst && !isNotWorking}
-			Snelheidslimiet: {properties.speed_limit} km/h<br />
+			Snelheidslimiet: {properties.speed_limit} km/u<br />
 			Hier zijn tussen {currentDate}
 			{currentHour} uur<br /> en {previousDate}
 			{previousHour} uur<br />

--- a/src/lib/components/MapPopup.svelte
+++ b/src/lib/components/MapPopup.svelte
@@ -1,9 +1,10 @@
 <script>
 	import { Badge } from 'spaper';
-	import { MetricEnum, SegmentStateEnum } from '../../types';
-	import { colorFeatureMetric } from '../../utils';
+	import { MetricEnum, SegmentStateEnum, ErrorSegmentState } from '../../types';
+	import { colorFeatureMetric, defaultColorMap } from '../../utils';
 
 	export let properties;
+	const defaultColors = defaultColorMap();
 	let previousDateString = properties.dateStart ?? properties.date;
 	let currentDateString = properties.dateEnd ?? properties.date;
 	if (previousDateString === currentDateString) {
@@ -24,20 +25,10 @@
 	const showSpeedLimit = properties.metric.showSpeedLimit;
 	const isNotWorking = isMetric && isNaN(properties.metrics?.[properties.metric.name]?.value);
 	let backgroundColor;
-	if (isNotWorking) {
-		// gray
-		backgroundColor = '#808080';
-	} else if (isMetric) {
+	if (isMetric) {
 		backgroundColor = colorFeatureMetric({ properties }, properties.metric);
-	} else if (properties.state === SegmentStateEnum.INACTIVE) {
-		// red
-		backgroundColor = 'ff0000';
-	} else if (properties.state === SegmentStateEnum.NEW) {
-		// orange
-		backgroundColor = '#ffa500';
 	} else {
-		// green
-		backgroundColor = '#3cb371';
+		backgroundColor = (defaultColors[properties?.state] || defaultColors[ErrorSegmentState]).color;
 	}
 	const style = `background-color=${backgroundColor}`;
 	const isInactive =

--- a/src/lib/components/MapPopup.svelte
+++ b/src/lib/components/MapPopup.svelte
@@ -1,105 +1,156 @@
 <script>
 	import { Badge } from 'spaper';
-	import {SegmentStateEnum} from '../../types';
+	import { MetricEnum, SegmentStateEnum } from '../../types';
 
 	export let properties;
-	let currentDateString = properties.date;
+	let previousDateString = properties.dateStart ?? properties.date;
+	let currentDateString = properties.dateEnd ?? properties.date;
+	if (previousDateString === currentDateString) {
+		try {
+			const currentTime = new Date(Date.parse(currentDateString)).getTime();
+			previousDateString = new Date().setTime(currentTime - 1000 * 60 * 60).toISOString();
+		} catch {
+			// In case of inactive sensors
+		}
+	}
 
 	let options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
 	const currentDateStr = new Date(Date.parse(currentDateString)).toLocaleString('nl-BE', options);
 	const currentHourNum = new Date(Date.parse(currentDateString)).getHours();
-	const previousHourNum = currentHourNum - 1;
-	const isInactive = properties.state === SegmentStateEnum.INACTIVE;
-	const isNew = properties.state === SegmentStateEnum.NEW;
+	const previousDateStr = new Date(Date.parse(previousDateString)).toLocaleString('nl-BE', options);
+	const previousHourNum = new Date(Date.parse(previousDateStr)).getHours();
+	const isMetric = properties.metric.name !== MetricEnum.NONE.name;
+	const isNotWorking = isMetric && isNaN(properties.metrics?.[properties.metric.name]?.rank);
+	const isInactive =
+		properties.state === SegmentStateEnum.INACTIVE ||
+		(isMetric &&
+			!isNaN(properties.metrics?.[properties.metric.name]?.rank) &&
+			properties.metrics[properties.metric.name].rank > 2);
+	const isNew =
+		properties.state === SegmentStateEnum.NEW ||
+		(isMetric &&
+			!isNaN(properties.metrics?.[properties.metric.name]?.rank) &&
+			properties.metrics[properties.metric.name].rank === 2);
+	const isFirst =
+		isMetric &&
+		!isNaN(properties.metrics?.[properties.metric.name]?.rank) &&
+		properties.metrics[properties.metric.name].rank === 1;
+	// const isInactive = properties.state === SegmentStateEnum.INACTIVE;
+	// const isNew = properties.state === SegmentStateEnum.NEW;
+
 	const isDefault = !isInactive && !isNew;
 	$: currentDate = currentDateStr === 'Invalid Date' ? '-' : currentDateStr;
+	$: previousDate = previousDateStr === 'Invalid Date' ? '-' : previousDateStr;
 	$: previousHour = isNaN(previousHourNum) ? '-' : previousHourNum;
 	$: currentHour = isNaN(currentHourNum) ? '-' : currentHourNum;
 </script>
 
-<div class="border padding-left-small padding-right-small shadow shadow-small" class:popup-inactive={isInactive} class:popup-new={isNew} class:popup={isDefault}>
+<div
+	class="border padding-left-small padding-right-small shadow shadow-small"
+	class:popup-not-working={isNotWorking}
+	class:popup-inactive-worst={isInactive}
+	class:popup-new-medium={isNew}
+	class:popup={isDefault}
+>
 	<h4>{properties.name}</h4>
-
 	<h5 class="child-borders">
-		{properties.state}<br/>
-		{#if isDefault}
-		Snelheidslimiet: {properties.speed_limit} km/h<br/>
-		Hier zijn op {currentDate}<br /> tussen {previousHour} en {currentHour} uur<br />
-		<Badge type="primary">
-			{Math.round(properties.pedestrian)}
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				xmlns:xlink="http://www.w3.org/1999/xlink"
-				aria-hidden="true"
-				role="img"
-				class="iconify iconify--gis"
-				width="32"
-				height="32"
-				preserveAspectRatio="xMidYMid meet"
-				viewBox="0 0 100 100"
-				><path
-					d="M55.017 7.5c-3.844 0-6.892 3.18-6.892 7.024s3.048 7.025 6.892 7.025c3.976 0 7.024-3.181 7.024-7.025c0-3.843-3.048-7.024-7.024-7.024zm-5.964 13.518c-1.458.133-2.651.928-3.579 1.59c-1.193.929-3.048 2.917-3.048 2.917v.132c-.133 0-7.422 8.482-11.663 12.458c-.398.398-.663.795-.795 1.326l-2.12 11.53c-.398 1.325.662 2.916 1.987 3.18c1.326.266 2.916-.794 3.048-2.252l2.121-10.736l8.217-8.217v21.868l-4.639 11.53L24.27 86.623a3.994 3.994 0 0 0-.663 2.784c.133.927.663 1.855 1.458 2.385c.795.663 1.855.795 2.916.663c.927-.265 1.855-.795 2.385-1.59v-.133l14.446-20.41l.398-.795l5.434-13.519l10.735 14.446l7.952 18.555c.663 1.723 3.048 2.65 4.771 1.855c1.723-.662 2.651-3.048 1.988-4.77l-8.084-18.82l-.398-.796L57.27 52.694V35.862l4.108 4.771l.398.398l10.602 8.217c.928.795 2.784.663 3.579-.398c.795-1.06.53-2.783-.398-3.71l-10.337-8.085c-3.181-3.711-7.29-8.88-9.145-11.265c-.928-1.193-3.314-4.374-6.362-4.772z"
-					fill="currentColor"
-					fill-rule="evenodd"
-				/></svg
-			>
-		</Badge>,
-		<Badge type="primary">
-			{Math.round(properties.bike)}
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				xmlns:xlink="http://www.w3.org/1999/xlink"
-				aria-hidden="true"
-				role="img"
-				class="iconify iconify--mdi"
-				width="32"
-				height="32"
-				preserveAspectRatio="xMidYMid meet"
-				viewBox="0 0 24 24"
-				><path
-					d="M5 20.5A3.5 3.5 0 0 1 1.5 17A3.5 3.5 0 0 1 5 13.5A3.5 3.5 0 0 1 8.5 17A3.5 3.5 0 0 1 5 20.5M5 12a5 5 0 0 0-5 5a5 5 0 0 0 5 5a5 5 0 0 0 5-5a5 5 0 0 0-5-5m9.8-2H19V8.2h-3.2l-1.94-3.27c-.29-.5-.86-.83-1.46-.83c-.47 0-.9.19-1.2.5L7.5 8.29C7.19 8.6 7 9 7 9.5c0 .63.33 1.16.85 1.47L11.2 13v5H13v-6.5l-2.25-1.65l2.32-2.35m5.93 13a3.5 3.5 0 0 1-3.5-3.5a3.5 3.5 0 0 1 3.5-3.5a3.5 3.5 0 0 1 3.5 3.5a3.5 3.5 0 0 1-3.5 3.5m0-8.5a5 5 0 0 0-5 5a5 5 0 0 0 5 5a5 5 0 0 0 5-5a5 5 0 0 0-5-5m-3-7.2c1 0 1.8-.8 1.8-1.8S17 1.2 16 1.2S14.2 2 14.2 3S15 4.8 16 4.8z"
-					fill="currentColor"
-				/></svg
-			>
-		</Badge>,
-		<Badge type="primary">
-			{Math.round(properties.car)}
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				xmlns:xlink="http://www.w3.org/1999/xlink"
-				aria-hidden="true"
-				role="img"
-				class="iconify iconify--mdi"
-				width="32"
-				height="32"
-				preserveAspectRatio="xMidYMid meet"
-				viewBox="0 0 24 24"
-				><path
-					d="M16 6H6l-5 6v3h2a3 3 0 0 0 3 3a3 3 0 0 0 3-3h6a3 3 0 0 0 3 3a3 3 0 0 0 3-3h2v-3c0-1.11-.89-2-2-2h-2l-3-4M6.5 7.5h4V10h-6l2-2.5m5.5 0h3.5l1.96 2.5H12V7.5m-6 6A1.5 1.5 0 0 1 7.5 15A1.5 1.5 0 0 1 6 16.5A1.5 1.5 0 0 1 4.5 15A1.5 1.5 0 0 1 6 13.5m12 0a1.5 1.5 0 0 1 1.5 1.5a1.5 1.5 0 0 1-1.5 1.5a1.5 1.5 0 0 1-1.5-1.5a1.5 1.5 0 0 1 1.5-1.5z"
-					fill="currentColor"
-				/></svg
-			>
-		</Badge>
-		en
-		<Badge type="primary">
-			{Math.round(properties.heavy)}
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				xmlns:xlink="http://www.w3.org/1999/xlink"
-				aria-hidden="true"
-				role="img"
-				class="iconify iconify--mdi"
-				width="32"
-				height="32"
-				preserveAspectRatio="xMidYMid meet"
-				viewBox="0 0 24 24"
-				><path
-					d="M18 18.5a1.5 1.5 0 0 1-1.5-1.5a1.5 1.5 0 0 1 1.5-1.5a1.5 1.5 0 0 1 1.5 1.5a1.5 1.5 0 0 1-1.5 1.5m1.5-9l1.96 2.5H17V9.5m-11 9A1.5 1.5 0 0 1 4.5 17A1.5 1.5 0 0 1 6 15.5A1.5 1.5 0 0 1 7.5 17A1.5 1.5 0 0 1 6 18.5M20 8h-3V4H3c-1.11 0-2 .89-2 2v11h2a3 3 0 0 0 3 3a3 3 0 0 0 3-3h6a3 3 0 0 0 3 3a3 3 0 0 0 3-3h2v-5l-3-4z"
-					fill="currentColor"
-				/></svg
-			>
-		</Badge>
-		gepasseerd.
+		{#if !isMetric}
+			{properties.state}<br />
+		{/if}
+		{#if isDefault && !isFirst && !isNotWorking}
+			Snelheidslimiet: {properties.speed_limit} km/h<br />
+			Hier zijn tussen {currentDate}
+			{currentHour} uur<br /> en {previousDate}
+			{previousHour} uur<br />
+			<Badge type="primary">
+				{Math.round(properties.pedestrian)}
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					xmlns:xlink="http://www.w3.org/1999/xlink"
+					aria-hidden="true"
+					role="img"
+					class="iconify iconify--gis"
+					width="32"
+					height="32"
+					preserveAspectRatio="xMidYMid meet"
+					viewBox="0 0 100 100"
+					><path
+						d="M55.017 7.5c-3.844 0-6.892 3.18-6.892 7.024s3.048 7.025 6.892 7.025c3.976 0 7.024-3.181 7.024-7.025c0-3.843-3.048-7.024-7.024-7.024zm-5.964 13.518c-1.458.133-2.651.928-3.579 1.59c-1.193.929-3.048 2.917-3.048 2.917v.132c-.133 0-7.422 8.482-11.663 12.458c-.398.398-.663.795-.795 1.326l-2.12 11.53c-.398 1.325.662 2.916 1.987 3.18c1.326.266 2.916-.794 3.048-2.252l2.121-10.736l8.217-8.217v21.868l-4.639 11.53L24.27 86.623a3.994 3.994 0 0 0-.663 2.784c.133.927.663 1.855 1.458 2.385c.795.663 1.855.795 2.916.663c.927-.265 1.855-.795 2.385-1.59v-.133l14.446-20.41l.398-.795l5.434-13.519l10.735 14.446l7.952 18.555c.663 1.723 3.048 2.65 4.771 1.855c1.723-.662 2.651-3.048 1.988-4.77l-8.084-18.82l-.398-.796L57.27 52.694V35.862l4.108 4.771l.398.398l10.602 8.217c.928.795 2.784.663 3.579-.398c.795-1.06.53-2.783-.398-3.71l-10.337-8.085c-3.181-3.711-7.29-8.88-9.145-11.265c-.928-1.193-3.314-4.374-6.362-4.772z"
+						fill="currentColor"
+						fill-rule="evenodd"
+					/></svg
+				>
+			</Badge>,
+			<Badge type="primary">
+				{Math.round(properties.bike)}
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					xmlns:xlink="http://www.w3.org/1999/xlink"
+					aria-hidden="true"
+					role="img"
+					class="iconify iconify--mdi"
+					width="32"
+					height="32"
+					preserveAspectRatio="xMidYMid meet"
+					viewBox="0 0 24 24"
+					><path
+						d="M5 20.5A3.5 3.5 0 0 1 1.5 17A3.5 3.5 0 0 1 5 13.5A3.5 3.5 0 0 1 8.5 17A3.5 3.5 0 0 1 5 20.5M5 12a5 5 0 0 0-5 5a5 5 0 0 0 5 5a5 5 0 0 0 5-5a5 5 0 0 0-5-5m9.8-2H19V8.2h-3.2l-1.94-3.27c-.29-.5-.86-.83-1.46-.83c-.47 0-.9.19-1.2.5L7.5 8.29C7.19 8.6 7 9 7 9.5c0 .63.33 1.16.85 1.47L11.2 13v5H13v-6.5l-2.25-1.65l2.32-2.35m5.93 13a3.5 3.5 0 0 1-3.5-3.5a3.5 3.5 0 0 1 3.5-3.5a3.5 3.5 0 0 1 3.5 3.5a3.5 3.5 0 0 1-3.5 3.5m0-8.5a5 5 0 0 0-5 5a5 5 0 0 0 5 5a5 5 0 0 0 5-5a5 5 0 0 0-5-5m-3-7.2c1 0 1.8-.8 1.8-1.8S17 1.2 16 1.2S14.2 2 14.2 3S15 4.8 16 4.8z"
+						fill="currentColor"
+					/></svg
+				>
+			</Badge>,
+			<Badge type="primary">
+				{Math.round(properties.car)}
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					xmlns:xlink="http://www.w3.org/1999/xlink"
+					aria-hidden="true"
+					role="img"
+					class="iconify iconify--mdi"
+					width="32"
+					height="32"
+					preserveAspectRatio="xMidYMid meet"
+					viewBox="0 0 24 24"
+					><path
+						d="M16 6H6l-5 6v3h2a3 3 0 0 0 3 3a3 3 0 0 0 3-3h6a3 3 0 0 0 3 3a3 3 0 0 0 3-3h2v-3c0-1.11-.89-2-2-2h-2l-3-4M6.5 7.5h4V10h-6l2-2.5m5.5 0h3.5l1.96 2.5H12V7.5m-6 6A1.5 1.5 0 0 1 7.5 15A1.5 1.5 0 0 1 6 16.5A1.5 1.5 0 0 1 4.5 15A1.5 1.5 0 0 1 6 13.5m12 0a1.5 1.5 0 0 1 1.5 1.5a1.5 1.5 0 0 1-1.5 1.5a1.5 1.5 0 0 1-1.5-1.5a1.5 1.5 0 0 1 1.5-1.5z"
+						fill="currentColor"
+					/></svg
+				>
+			</Badge>
+			en
+			<Badge type="primary">
+				{Math.round(properties.heavy)}
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					xmlns:xlink="http://www.w3.org/1999/xlink"
+					aria-hidden="true"
+					role="img"
+					class="iconify iconify--mdi"
+					width="32"
+					height="32"
+					preserveAspectRatio="xMidYMid meet"
+					viewBox="0 0 24 24"
+					><path
+						d="M18 18.5a1.5 1.5 0 0 1-1.5-1.5a1.5 1.5 0 0 1 1.5-1.5a1.5 1.5 0 0 1 1.5 1.5a1.5 1.5 0 0 1-1.5 1.5m1.5-9l1.96 2.5H17V9.5m-11 9A1.5 1.5 0 0 1 4.5 17A1.5 1.5 0 0 1 6 15.5A1.5 1.5 0 0 1 7.5 17A1.5 1.5 0 0 1 6 18.5M20 8h-3V4H3c-1.11 0-2 .89-2 2v11h2a3 3 0 0 0 3 3a3 3 0 0 0 3-3h6a3 3 0 0 0 3 3a3 3 0 0 0 3-3h2v-5l-3-4z"
+						fill="currentColor"
+					/></svg
+				>
+			</Badge>
+			gepasseerd.
+		{/if}
+		{#if isMetric && !isNotWorking}
+			Hier scoorde {properties.name}
+			{properties.metrics[properties.metric.name].rank}e<br />
+			met {Math.round(properties.metrics[properties.metric.name].value * 100) / 100}
+			{properties.metric.metricName}<br />
+			tussen {currentDate}
+			{currentHour} uur<br /> en {previousDate}
+			{previousHour} uur
+		{/if}
+		{#if isMetric && isNotWorking}
+			{properties.state}<br />
+			Geen data voor<br />
+			{properties.metric.name}
 		{/if}
 	</h5>
 	<a href="https://telraam.net/nl/location/{properties.segment_id}">Toon me meer data...</a>
@@ -110,12 +161,16 @@
 		background-color: #3cb371;
 	}
 
-	.popup-inactive {
+	.popup-inactive-worst {
 		background-color: #ff0000;
 	}
 
-	.popup-new {
+	.popup-new-medium {
 		background-color: #ffa500;
+	}
+
+	.popup-not-working {
+		background-color: #808080;
 	}
 
 	.popup a {

--- a/src/lib/components/MapPopup.svelte
+++ b/src/lib/components/MapPopup.svelte
@@ -23,6 +23,7 @@
 	<h5 class="child-borders">
 		{properties.state}<br/>
 		{#if isDefault}
+		Snelheidslimiet: {properties.speed_limit} km/h<br/>
 		Hier zijn op {currentDate}<br /> tussen {previousHour} en {currentHour} uur<br />
 		<Badge type="primary">
 			{Math.round(properties.pedestrian)}

--- a/src/routes/api/current_traffic.js
+++ b/src/routes/api/current_traffic.js
@@ -34,7 +34,7 @@ export async function get(request) {
 			redirect: 'follow'
 		});
 		if (res.ok) {
-			console.log('Most recent traffic request from Telraam succesfull.');
+			console.log('Most recent traffic request from Telraam successful.');
 			return {
 				statusCode: 200,
 				headers: {

--- a/src/routes/api/current_traffic.js
+++ b/src/routes/api/current_traffic.js
@@ -6,7 +6,7 @@ const limiter = rateLimit({
 });
 
 export async function get(request) {
-	const limit = parseInt(import.meta.env.VITE_API_LIMIT, 10); // number of requests per minute
+	const limit = parseInt(import.meta.env.VITE_API_LIMIT, 10) || 10; // number of requests per minute
 	const currentUsage = await limiter.check(request, limit, 'CACHE_TOKEN');
 	const isRateLimited = currentUsage >= parseInt(limit, 10);
 

--- a/src/routes/api/speed-[segmentid]-[timeStart]-[timeEnd].js
+++ b/src/routes/api/speed-[segmentid]-[timeStart]-[timeEnd].js
@@ -6,9 +6,9 @@ const limiter = rateLimit({
 });
 
 export async function get(request) {
-	const limit = parseInt(import.meta.env.VITE_API_LIMIT, 200); // number of requests per minute
+	const limit = parseInt(import.meta.env.VITE_API_LIMIT, 20); // number of requests per minute
 	const currentUsage = await limiter.check(request, limit, 'CACHE_TOKEN');
-	const isRateLimited = currentUsage >= parseInt(limit, 100);
+	const isRateLimited = currentUsage >= parseInt(limit, 10);
 
 	if (isRateLimited) {
 		console.log('Rate limit exceeded...');

--- a/src/routes/api/speed-[segmentid]-[timeStart]-[timeEnd].js
+++ b/src/routes/api/speed-[segmentid]-[timeStart]-[timeEnd].js
@@ -6,9 +6,9 @@ const limiter = rateLimit({
 });
 
 export async function get(request) {
-	const limit = parseInt(import.meta.env.VITE_API_LIMIT, 20); // number of requests per minute
+	const limit = parseInt(import.meta.env.VITE_API_LIMIT, 200); // number of requests per minute
 	const currentUsage = await limiter.check(request, limit, 'CACHE_TOKEN');
-	const isRateLimited = currentUsage >= parseInt(limit, 10);
+	const isRateLimited = currentUsage >= parseInt(limit, 100);
 
 	if (isRateLimited) {
 		console.log('Rate limit exceeded...');
@@ -22,7 +22,7 @@ export async function get(request) {
 		const token = import.meta.env.VITE_TELRAAM_API_KEY;
 		const url = 'https://telraam-api.net/v1/reports/traffic';
 		// Note -> did not work with json.stringify, so defined as raw body
-		let raw = `{\r\n \"level\":\"segments\",\r\n \"format\":\"per-hour\",\r\n \"id\":\"${request.params.segmentid}\",\r\n \"time_start\":\"2021-12-01 12:00:00Z\",\r\n \"time_end\":\"2021-12-02 12:00:00Z\"}\r\n`;
+		let raw = `{\r\n \"level\":\"segments\",\r\n \"format\":\"per-hour\",\r\n \"id\":\"${request.params.segmentid}\",\r\n \"time_start\":\"${request.params.timeStart}\",\r\n \"time_end\":\"${request.params.timeEnd}\"}\r\n`;
 
 		const res = await fetch(url, {
 			method: 'POST',

--- a/src/routes/api/speed-[segmentid]-[timeStart]-[timeEnd].js
+++ b/src/routes/api/speed-[segmentid]-[timeStart]-[timeEnd].js
@@ -2,7 +2,7 @@ import rateLimit from '../_utils/_lru_cache';
 
 const limiter = rateLimit({
 	interval: 60 * 1000, // 60 seconds
-	uniqueTokenPerInterval: 10 // Max 10 users per second
+	uniqueTokenPerInterval: 20 // Max 10 users per second
 });
 
 export async function get(request) {
@@ -17,7 +17,6 @@ export async function get(request) {
 			error: new Error(`Rate limit exceeded.`)
 		};
 	} else {
-		console.log(`${request.params.segmentid}`);
 		console.log('Requesting speed data from API telraam...');
 		const token = import.meta.env.VITE_TELRAAM_API_KEY;
 		const url = 'https://telraam-api.net/v1/reports/traffic';

--- a/src/routes/api/speed-[segmentid]-[timeStart]-[timeEnd].js
+++ b/src/routes/api/speed-[segmentid]-[timeStart]-[timeEnd].js
@@ -6,7 +6,7 @@ const limiter = rateLimit({
 });
 
 export async function get(request) {
-	const limit = parseInt(import.meta.env.VITE_API_LIMIT, 20); // number of requests per minute
+	const limit = parseInt(import.meta.env.VITE_API_LIMIT, 10) || 20; // number of requests per minute
 	const currentUsage = await limiter.check(request, limit, 'CACHE_TOKEN');
 	const isRateLimited = currentUsage >= parseInt(limit, 10);
 

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -55,11 +55,17 @@
 	let switch1 = false;
 	let switch2 = false;
 	let switch3 = false;
-	const updateMetric = (m) => {
+	const updateMetric = (m, v) => {
 		// TODO can this easily be generalized?
+		console.log('here');
 		switch (m) {
 			case MetricEnum.VULNERABLE_ROAD_USER_TO_CAR: {
 				if (switch1 === false) {
+					if (switch2 || switch3) {
+						// This is only triggered by enabling another metric.
+						// Ignore in this case.
+						return;
+					}
 					metric = MetricEnum.NONE;
 				} else {
 					metric = m;
@@ -70,6 +76,11 @@
 			}
 			case MetricEnum.TOO_FAST_120_PERCENT: {
 				if (switch2 === false) {
+					if (switch1 || switch3) {
+						// This is only triggered by enabling another metric.
+						// Ignore in this case.
+						return;
+					}
 					metric = MetricEnum.NONE;
 				} else {
 					metric = m;
@@ -80,6 +91,11 @@
 			}
 			case MetricEnum.TOO_FAST_120_PERCENT_PLUS: {
 				if (switch3 === false) {
+					if (switch1 || switch2) {
+						// This is only triggered by enabling another metric.
+						// Ignore in this case.
+						return;
+					}
 					metric = MetricEnum.NONE;
 				} else {
 					metric = m;
@@ -90,12 +106,12 @@
 			}
 		}
 	};
-	$: switch1 && updateMetric(MetricEnum.VULNERABLE_ROAD_USER_TO_CAR);
-	$: !switch1 && updateMetric(MetricEnum.VULNERABLE_ROAD_USER_TO_CAR);
-	$: switch2 && updateMetric(MetricEnum.TOO_FAST_120_PERCENT);
-	$: !switch2 && updateMetric(MetricEnum.TOO_FAST_120_PERCENT);
-	$: switch3 && updateMetric(MetricEnum.TOO_FAST_120_PERCENT_PLUS);
-	$: !switch3 && updateMetric(MetricEnum.TOO_FAST_120_PERCENT_PLUS);
+	$: switch1 && updateMetric(MetricEnum.VULNERABLE_ROAD_USER_TO_CAR, true);
+	$: !switch1 && updateMetric(MetricEnum.VULNERABLE_ROAD_USER_TO_CAR, false);
+	$: switch2 && updateMetric(MetricEnum.TOO_FAST_120_PERCENT, true);
+	$: !switch2 && updateMetric(MetricEnum.TOO_FAST_120_PERCENT, false);
+	$: switch3 && updateMetric(MetricEnum.TOO_FAST_120_PERCENT_PLUS, true);
+	$: !switch3 && updateMetric(MetricEnum.TOO_FAST_120_PERCENT_PLUS, false);
 	export let snapshot = [];
 	const timeEnd = new Date();
 	let timeStart = new Date(timeEnd);

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -129,6 +129,7 @@
 		)
 			.then((speeds) => {
 				const updateProperties = speeds.map((speed) => aggregateTrafficSnapshotData(speed.report));
+				console.log(`Unknown segments: `, updateProperties.filter(p => p.name === '').map(p => p.segment_id));
 				const updatedSnapshot = JSON.parse(JSON.stringify(snapshot));
 				updateProperties.forEach((prop, idx) => {
 					if (prop.name !== '') {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -128,7 +128,7 @@
 					}-${timeStart.toUTCString()}-${timeEnd.toUTCString()}`
 			),
 			1100,
-			10
+			3
 		)
 			.then((speeds) => {
 				const timeEndCall = new Date();

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,13 +1,13 @@
 <script context="module">
 	import { segmentProperties } from '../types';
-	import { getSegmentState, aggregateTrafficSnapshotData } from '../utils';
+	import { getSegmentState, aggregateTrafficSnapshotData, sortMetric } from '../utils';
 	export async function load({ fetch }) {
 		const res = await fetch('/api/current_traffic');
-		if (res.ok) {			
+		if (res.ok) {
 			const resp = await res.json();
 			console.log(resp);
 			/** @type {Array.<SegmentGeoJSONData>} snapshot */
-			const snapshot = resp.features.map(el => ({
+			let snapshot = resp.features.map((el) => ({
 				type: el.type,
 				geometry: el.geometry,
 				properties: {
@@ -47,39 +47,111 @@
 
 <script>
 	import { onMount } from 'svelte';
+	import { Switch } from 'spaper';
 	import Map from '$lib/components/Map.svelte';
+	import { MetricEnum } from '../types';
+	export let metric = MetricEnum.NONE;
+	let metricsAvailable = false;
+	let switch1 = false;
+	let switch2 = false;
+	let switch3 = false;
+	const updateMetric = (m) => {
+		// TODO can this easily be generalized?
+		switch (m) {
+			case MetricEnum.VULNERABLE_ROAD_USER_TO_CAR: {
+				if (switch1 === false) {
+					metric = MetricEnum.NONE;
+				} else {
+					metric = m;
+					switch2 = false;
+					switch3 = false;
+				}
+				break;
+			}
+			case MetricEnum.TOO_FAST_120_PERCENT: {
+				if (switch2 === false) {
+					metric = MetricEnum.NONE;
+				} else {
+					metric = m;
+					switch1 = false;
+					switch3 = false;
+				}
+				break;
+			}
+			case MetricEnum.TOO_FAST_120_PERCENT_PLUS: {
+				if (switch3 === false) {
+					metric = MetricEnum.NONE;
+				} else {
+					metric = m;
+					switch1 = false;
+					switch2 = false;
+				}
+				break;
+			}
+		}
+	};
+	$: switch1 && updateMetric(MetricEnum.VULNERABLE_ROAD_USER_TO_CAR);
+	$: !switch1 && updateMetric(MetricEnum.VULNERABLE_ROAD_USER_TO_CAR);
+	$: switch2 && updateMetric(MetricEnum.TOO_FAST_120_PERCENT);
+	$: !switch2 && updateMetric(MetricEnum.TOO_FAST_120_PERCENT);
+	$: switch3 && updateMetric(MetricEnum.TOO_FAST_120_PERCENT_PLUS);
+	$: !switch3 && updateMetric(MetricEnum.TOO_FAST_120_PERCENT_PLUS);
 	export let snapshot = [];
 	const timeEnd = new Date();
 	let timeStart = new Date(timeEnd);
 	timeStart.setMonth(timeStart.getMonth() - 1);
 	onMount(() => {
 		const updateProperties = Promise.all(
-	        snapshot.map(segment => {
-	            return fetch(`/api/speed-${segment.properties.segment_id}-${timeStart.toUTCString()}-${timeEnd.toUTCString()}`);
-	        })
-	    ).then(responses => {
-	        return Promise.all(responses.map(res => {
-	            return res.json()
-	        }));
-	    }).then(speeds => {
-			const updateProperties = speeds.map(speed => aggregateTrafficSnapshotData(speed.report));
-			const updatedSnapshot = JSON.parse(JSON.stringify(snapshot));
-			updateProperties.forEach((prop, idx) => {
-				if (prop.name !== '') {
-					updatedSnapshot[idx].properties = prop;
-				}
+			snapshot.map((segment) => {
+				return fetch(
+					`/api/speed-${
+						segment.properties.segment_id
+					}-${timeStart.toUTCString()}-${timeEnd.toUTCString()}`
+				);
+			})
+		)
+			.then((responses) => {
+				return Promise.all(
+					responses.map((res) => {
+						return res.json();
+					})
+				);
+			})
+			.then((speeds) => {
+				const updateProperties = speeds.map((speed) => aggregateTrafficSnapshotData(speed.report));
+				const updatedSnapshot = JSON.parse(JSON.stringify(snapshot));
+				updateProperties.forEach((prop, idx) => {
+					if (prop.name !== '') {
+						updatedSnapshot[idx].properties = prop;
+					}
+				});
+				Object.values(MetricEnum)
+					.filter((m) => m.name !== MetricEnum.NONE.name)
+					.forEach((m) => {
+						const updatedMetrics = sortMetric(
+							updatedSnapshot.map((s) => s.properties.metrics?.[m.name]),
+							m.decreasing
+						);
+						updatedMetrics.forEach((um, i) => {
+							if (um) {
+								updatedSnapshot[i].properties.metrics[m.name] = um;
+							}
+						});
+					});
+				metricsAvailable = true;
+				snapshot = updatedSnapshot;
+			})
+			.catch((error) => {
+				console.log(error);
 			});
-			return {
-				props: {
-					snapshot: updatedSnapshot
-				}
-			};
-	    }).catch(error => {
-	        console.log(error);
-	    });
 	});
 	// $: segments = snapshot.features.map(x => x.properties.segment_id)
 </script>
 
 <!-- {segments} -->
-<Map {snapshot} />
+<Map {snapshot} {metric} />
+<div id="metric-group" class="border paper form-group flex-spaces" hidden={!metricsAvailable}>
+	<Switch bind:checked={switch1}>{MetricEnum.VULNERABLE_ROAD_USER_TO_CAR.name}</Switch><br />
+	<Switch bind:checked={switch2}>{MetricEnum.TOO_FAST_120_PERCENT.name}</Switch><br />
+	<Switch bind:checked={switch3}>{MetricEnum.TOO_FAST_120_PERCENT_PLUS.name}</Switch><br />
+</div>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -132,9 +132,12 @@
 		)
 			.then((speeds) => {
 				const timeEndCall = new Date();
-				console.log(`Calls took ${timeEndCall.getTime() - timeStartCall.getTime()} ms`)
+				console.log(`Calls took ${timeEndCall.getTime() - timeStartCall.getTime()} ms`);
 				const updateProperties = speeds.map((speed) => aggregateTrafficSnapshotData(speed.report));
-				console.log(`Unknown segments: `, updateProperties.filter(p => p.name === '').map(p => p.segment_id));
+				console.log(
+					`Unknown segments: `,
+					updateProperties.filter((p) => p.name === '').map((p) => p.segment_id)
+				);
 				const updatedSnapshot = JSON.parse(JSON.stringify(snapshot));
 				updateProperties.forEach((prop, idx) => {
 					if (prop.name !== '') {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -114,10 +114,12 @@
 	$: switch3 && updateMetric(MetricEnum.SPEEDING_VIOLATION_SPEED, true);
 	$: !switch3 && updateMetric(MetricEnum.SPEEDING_VIOLATION_SPEED, false);
 	export let snapshot = [];
+	let timeStartCall;
 	const timeEnd = new Date();
 	let timeStart = new Date(timeEnd);
 	timeStart.setDate(timeStart.getDate() - 7);
 	onMount(() => {
+		timeStartCall = new Date();
 		const updateProperties = chainFetches(
 			snapshot.map(
 				(segment) =>
@@ -125,9 +127,12 @@
 						segment.properties.segment_id
 					}-${timeStart.toUTCString()}-${timeEnd.toUTCString()}`
 			),
-			1100 // avoid rate-limiting telraam API
+			1100,
+			10
 		)
 			.then((speeds) => {
+				const timeEndCall = new Date();
+				console.log(`Calls took ${timeEndCall.getTime() - timeStartCall.getTime()} ms`)
 				const updateProperties = speeds.map((speed) => aggregateTrafficSnapshotData(speed.report));
 				console.log(`Unknown segments: `, updateProperties.filter(p => p.name === '').map(p => p.segment_id));
 				const updatedSnapshot = JSON.parse(JSON.stringify(snapshot));

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -125,7 +125,7 @@
 						segment.properties.segment_id
 					}-${timeStart.toUTCString()}-${timeEnd.toUTCString()}`
 			),
-			1.1 // avoid rate-limiting telraam API
+			1100 // avoid rate-limiting telraam API
 		)
 			.then((speeds) => {
 				const updateProperties = speeds.map((speed) => aggregateTrafficSnapshotData(speed.report));
@@ -140,8 +140,7 @@
 					.forEach((m) => {
 						const updatedMetrics = sortMetric(
 							updatedSnapshot.map((s) => s.properties.metrics?.[m.name]),
-							m.decreasing,
-							m.computeRank
+							m.decreasing
 						);
 						updatedMetrics.forEach((um, i) => {
 							if (um) {

--- a/src/types.js
+++ b/src/types.js
@@ -9,6 +9,7 @@ export const SegmentStateEnum = {
 	NEW: 'Recent toegevoegd, nog geen data beschikbaar',
 	INACTIVE: 'Niet actief, geen data beschikbaar'
 };
+export const ErrorSegmentState = 'Onverwacht';
 
 const computeVulnerableCarRatio = (records) => {
 	let bike = 0;
@@ -74,6 +75,7 @@ export const MetricEnum = {
 		decreasing: false,
 		showSpeedLimit: false,
 		metricName: 'zwakke weggebruikers / voertuig',
+		metricUnit: '',
 		colormap: [
 			{
 				value: 0.2,
@@ -107,6 +109,7 @@ export const MetricEnum = {
 		decreasing: false,
 		showSpeedLimit: true,
 		metricName: '% van de chauffeurs binnen de snelheidslimiet',
+		metricUnit: '%',
 		colormap: [
 			{
 				value: 65,
@@ -140,6 +143,7 @@ export const MetricEnum = {
 		decreasing: true,
 		showSpeedLimit: true,
 		metricName: 'km/u boven snelheidslimiet',
+		metricUnit: 'km/u',
 		colormap: [
 			{
 				value: 25,

--- a/src/types.js
+++ b/src/types.js
@@ -12,15 +12,45 @@ export const SegmentStateEnum = {
 
 /**
  * @typedef {Object} SegmentData
- * @property {string} segment_id
+ * @property {number} segment_id
  * @property {string} name
+ * @property {number} speed_limit
  * @property {string} date
  * @property {number} pedestrian
  * @property {number} bike
  * @property {number} car
  * @property {number} heavy
+ * @property {number} total_hours (only present in case of a traffic_snapshot call)
+ * @property {number} uptime (only present in case of a traffic_snapshot call)
+ * @property {RankingMetric} vulnerable_road_user_to_car_ratio (only present in case of a traffic_snapshot call)
+ * @property {RankingMetric} too_fast_120_percent (only present in case of a traffic_snapshot call, 100-120% of speed limit)
+ * @property {RankingMetric} too_fast_120_percent_plus (only present in case of a traffic_snapshot call, >120% of speed limit)
  * @property {SegmentStateEnum} state
  * @property {string} last_data_package
+ */
+
+/**
+ * @typedef {Object} TrafficSnapshotData
+ * @property {number} segment_id
+ * @property {number} instance_id
+ * @property {string} interval ("hourly" or "daily")
+ * @property {string} timezone
+ * @property {number} uptime
+ * @property {number} v85
+ * @property {number} direction (1 or 0, 1 is aligned with "virtual" segment direction)
+ * @property {number} pedestrian (..._lft & _rgt also exist)
+ * @property {number} bike (..._lft & _rgt also exist)
+ * @property {number} car (..._lft & _rgt also exist)
+ * @property {number} heavy (..._lft & _rgt also exist)
+ * @property {Array<number>} car_speed_hist_0to70plus (bins of 10km/h - 0 to 7)
+ * @property {Array<number>} car_speed_hist_0to120plus (bins of 5km/h - 0 to 24)
+ * @property {string} last_data_package
+ */
+
+/**
+ * @typedef {Object} RankingMetric
+ * @property {number} value
+ * @property {number} rank
  */
 
 /**
@@ -30,15 +60,57 @@ export const SegmentStateEnum = {
  * @property {SegmentData} properties
  */
 
+/**
+ * @typedef {Object} SegmentProperties
+ * @property {string} name
+ * @property {number} speed_limit
+ */
+
 // TODO - add API call to get location metadata instead of hardcoding
 /** @type {Object.<number,string>} */
-export const segmentNames = {
-	9000003081: 'Dahliastraat',
-	9000000795: 'Pannestraat',
-	529611: 'Gasmeterlaan',
-	9000003002: 'Mimosastraat',
-	9000003050: 'Fuchsiastraat',
-	9000003058: 'Klaverstraat',
-	9000003062: 'Dracenastraat',
-	9000003073: 'Grensstraat'
+const streets = [
+	529611, 9000000795, 9000002436, 9000003002, 9000003050, 9000003058, 9000003062, 9000003073,
+	9000003081, 9000003094
+];
+export const segmentProperties = {
+	9000002436: {
+		name: 'Dahliastraat',
+		speed_limit: 50 // TODO look up
+	},
+	9000000795: {
+		name: 'Pannestraat',
+		speed_limit: 50 // TODO look up
+	},
+	529611: {
+		name: 'Gasmeterlaan',
+		speed_limit: 50 // TODO look up
+	},
+	9000003002: {
+		name: 'Mimosastraat',
+		speed_limit: 50 // TODO look up
+	},
+	9000003050: {
+		name: 'Fuchsiastraat',
+		speed_limit: 50 // TODO look up
+	},
+	9000003058: {
+		name: 'Klaverstraat',
+		speed_limit: 50 // TODO look up
+	},
+	9000003062: {
+		name: 'Dracenastraat',
+		speed_limit: 50 // TODO look up
+	},
+	9000003073: {
+		name: 'Grensstraat',
+		speed_limit: 50 // TODO look up
+	},
+	9000003081: {
+		name: 'Dahliastraat',
+		speed_limit: 50 // TODO look up
+	},
+	9000003094: {
+		name: 'Francisco Ferrerlaan',
+		speed_limit: 50 // TODO look up
+	}
 };

--- a/src/types.js
+++ b/src/types.js
@@ -109,27 +109,27 @@ export const MetricEnum = {
 		metricName: '% van de chauffeurs binnen de snelheidslimiet',
 		colormap: [
 			{
-				value: 0.65,
+				value: 65,
 				color: '#ff0000'
 			},
 			{
-				value: 0.7,
+				value: 70,
 				color: '#ff5349'
 			},
 			{
-				value: 0.75,
+				value: 75,
 				color: '#fa500'
 			},
 			{
-				value: 0.8,
+				value: 80,
 				color: '#ffae42'
 			},
 			{
-				value: 0.85,
+				value: 85,
 				color: '#ffff00'
 			},
 			{
-				value: 0.9,
+				value: 90,
 				color: '#9acd32'
 			}
 		]
@@ -268,6 +268,26 @@ export const segmentProperties = {
 		speed_limit: 50
 	},
 	9000003149: {
+		name: 'Maïsstraat',
+		speed_limit: 30
+	},
+	9000003136: {
+		name: 'Anjelierstraat',
+		speed_limit: 30
+	},
+	9000003246: {
+		name: 'Frans Van Ryhovelaan',
+		speed_limit: 30
+	},
+	9000003275: {
+		name: 'Maïsstraat',
+		speed_limit: 30
+	},
+	9000003278: {
+		name: 'Poperingestraat',
+		speed_limit: 30
+	},
+	9000003281: {
 		name: 'Maïsstraat',
 		speed_limit: 30
 	}

--- a/src/types.js
+++ b/src/types.js
@@ -147,46 +147,46 @@ export const MetricEnum = {
 export const segmentProperties = {
 	9000002436: {
 		name: 'Dahliastraat',
-		speed_limit: 50 // TODO look up
+		speed_limit: 30
 	},
 	9000000795: {
 		name: 'Pannestraat',
-		speed_limit: 50 // TODO look up
+		speed_limit: 30
 	},
 	529611: {
 		name: 'Gasmeterlaan',
-		speed_limit: 50 // TODO look up
+		speed_limit: 50
 	},
 	9000003002: {
 		name: 'Mimosastraat',
-		speed_limit: 50 // TODO look up
+		speed_limit: 30
 	},
 	9000003050: {
 		name: 'Fuchsiastraat',
-		speed_limit: 50 // TODO look up
+		speed_limit: 30
 	},
 	9000003058: {
 		name: 'Klaverstraat',
-		speed_limit: 50 // TODO look up
+		speed_limit: 30
 	},
 	9000003062: {
 		name: 'Dracenastraat',
-		speed_limit: 50 // TODO look up
+		speed_limit: 50
 	},
 	9000003073: {
 		name: 'Grensstraat',
-		speed_limit: 50 // TODO look up
+		speed_limit: 30
 	},
 	9000003081: {
 		name: 'Dahliastraat',
-		speed_limit: 50 // TODO look up
+		speed_limit: 30
 	},
 	9000003094: {
 		name: 'Francisco Ferrerlaan',
-		speed_limit: 50 // TODO look up
+		speed_limit: 50
 	},
 	9000003149: {
 		name: 'Maïsstraat',
-		speed_limit: 50 // TODO look up
+		speed_limit: 30
 	}
 };

--- a/src/types.js
+++ b/src/types.js
@@ -73,30 +73,99 @@ export const MetricEnum = {
 		computeMetric: computeVulnerableCarRatio,
 		decreasing: false,
 		showSpeedLimit: false,
-		metricName: 'zwakke weggebruikers / voertuig'
+		metricName: 'zwakke weggebruikers / voertuig',
+		colormap: [
+			{
+				value: 0.2,
+				color: '#ff0000'
+			},
+			{
+				value: 0.4,
+				color: '#ff5349'
+			},
+			{
+				value: 0.6,
+				color: '#fa500'
+			},
+			{
+				value: 0.8,
+				color: '#ffae42'
+			},
+			{
+				value: 1,
+				color: '#ffff00'
+			},
+			{
+				value: 1.2,
+				color: '#9acd32'
+			}
+		]
 	},
 	RATIO_SPEEDING_VIOLATION: {
 		name: '% chauffeurs binnen snelheidslimiet',
 		computeMetric: computeCorrectSpeedRatio,
 		decreasing: false,
 		showSpeedLimit: true,
-		computeRank: (x) => {
-			// 3 categorieën: >= 85% goede chauffeurs, >= 75% goede chauffeurs, < 75% goede chauffeurs
-			if (x < 75) {
-				return 3;
-			} else if (x < 85) {
-				return 2;
+		metricName: '% van de chauffeurs binnen de snelheidslimiet',
+		colormap: [
+			{
+				value: 0.65,
+				color: '#ff0000'
+			},
+			{
+				value: 0.7,
+				color: '#ff5349'
+			},
+			{
+				value: 0.75,
+				color: '#fa500'
+			},
+			{
+				value: 0.8,
+				color: '#ffae42'
+			},
+			{
+				value: 0.85,
+				color: '#ffff00'
+			},
+			{
+				value: 0.9,
+				color: '#9acd32'
 			}
-			return 1;
-		},
-		metricName: '% van de chauffeurs binnen de snelheidslimiet'
+		]
 	},
 	SPEEDING_VIOLATION_SPEED: {
 		name: 'Gemiddelde snelheid bij snelheidsovertreding',
 		computeMetric: computeSpeedingViolationSpeed,
 		decreasing: true,
 		showSpeedLimit: true,
-		metricName: 'km/u boven snelheidslimiet'
+		metricName: 'km/u boven snelheidslimiet',
+		colormap: [
+			{
+				value: 25,
+				color: '#ff0000'
+			},
+			{
+				value: 20,
+				color: '#ff5349'
+			},
+			{
+				value: 15,
+				color: '#fa500'
+			},
+			{
+				value: 10,
+				color: '#ffae42'
+			},
+			{
+				value: 5,
+				color: '#ffff00'
+			},
+			{
+				value: 0,
+				color: '#9acd32'
+			}
+		]
 	}
 };
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -165,3 +165,25 @@ export async function chainFetches(urls, delayMs = 0, toJson = true) {
 	}
 	return responses;
 }
+
+/**
+ * @function
+ * @param feature RankingMetric
+ * @param mt MetricProps
+ * @return color hex
+ */
+export function colorFeatureMetric(feature, mt) {
+	const featureValue = feature.properties.metrics?.[mt.name].value;
+	if (featureValue === undefined || featureValue == 0 || isNaN(featureValue)) {
+		return '#808080';
+	}
+	for (let { value, color } of mt.colormap) {
+		if (mt.decreasing && featureValue > value) {
+			return color;
+		} else if (!mt.decreasing && featureValue < value) {
+			return color;
+		}
+	}
+	// outside of boundaries dictated by colormap
+	return mt.colormap[mt.colormap.length - 1].color;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,110 @@
+import { SegmentStateEnum, segmentProperties } from './types';
+
+/**
+ * @function
+ * @param records SegmentData
+ * @return SegmentStateEnum
+ */
+export function getSegmentState(segmentData) {
+	if (segmentData.pedestrian === '' && segmentData.last_data_package) {
+		return SegmentStateEnum.INACTIVE;
+	} else if (segmentData.pedestrian === '') {
+		return SegmentStateEnum.NEW;
+	}
+	return SegmentStateEnum.ACTIVE;
+}
+
+/**
+ * @function
+ * @param records Array<TrafficSnapshotData>
+ * @return SegmentData
+ */
+export function aggregateTrafficSnapshotData(records) {
+	if (!Array.isArray(records) || records.length === 0) {
+		return {
+			segment_id: 0,
+			name: '',
+			date: '',
+			pedestrian: 0,
+			bike: 0,
+			car: 0,
+			heavy: 0,
+			total_hours: 0,
+			uptime: 0,
+			vulnerable_road_user_to_car_ratio: null,
+			too_fast_120_percent: null,
+			too_fast_120_percent_plus: null,
+			state: '',
+			last_data_package: ''
+		};
+	}
+	const segment_id = records[0].segment_id;
+	const total_uptime = records.reduce((sum, rc) => sum + rc.uptime, 0);
+	const total_hours = records.reduce((sum, rc) => {
+		if (rc.interval === 'hourly') {
+			sum += 1;
+		} else if (rc.interval === 'daily') {
+			sum += 24;
+		} else {
+			console.error(`Unexpected interval value ${rc.interval} for segment ${segment_id}`);
+		}
+		return sum;
+	}, 0);
+	const out = {
+		segment_id: segment_id,
+		name: segmentProperties[segment_id]?.name || '',
+		speed_limit: segmentProperties[segment_id]?.speed_limit || '',
+		date: records[-1]?.speed_limit,
+		pedestrian: 0,
+		bike: 0,
+		car: 0,
+		heavy: 0,
+		total_hours: 0,
+		uptime: 0,
+		vulnerable_road_user_to_car_ratio: {
+			value: 0,
+			rank: 0
+		},
+		too_fast_120_percent: {
+			value: 0,
+			rank: 0
+		},
+		too_fast_120_percent_plus: {
+			value: 0,
+			rank: 0
+		},
+		// current state, expecting chronological ordering
+		state: getSegmentState(records[records.length - 1]),
+		last_data_package: records[records.length - 1].last_data_package
+	};
+	let all_hist_values = 0;
+	records.forEach((rc) => {
+		out.uptime += rc.uptime;
+		if (rc.interval === 'hourly') {
+			out.total_hours += 1;
+		} else if (rc.interval === 'daily') {
+			out.total_hours += 24;
+		} else {
+			console.error(`Unexpected interval value ${rc.interval} for segment ${segment_id}`);
+		}
+		out.pedestrian += rc.pedestrian;
+		out.bike += rc.bike;
+		out.car += rc.car;
+		out.heavy += rc.heavy;
+		all_hist_values += rc.car_speed_hist_0to120plus.reduce((s, hist) => s + hist, 0);
+		out.too_fast_120_percent.value += rc.car_speed_hist_0to120plus.reduce(
+			(s, hist, idx) =>
+				s + ((idx + 1) * 5 > out.speed_limit && (idx + 1) * 5 <= 1.2 * out.speed_limit) * hist,
+			0
+		);
+		out.too_fast_120_percent_plus.value = rc.car_speed_hist_0to120plus.reduce(
+			(s, hist, idx) => s + ((idx + 1) * 5 > 1.2 * out.speed_limit) * hist,
+			0
+		);
+	});
+	out.uptime /= records.length;
+	out.too_fast_120_percent.value /= all_hist_values;
+	out.too_fast_120_percent_plus.value /= all_hist_values;
+	out.vulnerable_road_user_to_car_ratio.value = (out.bike + out.pedestrian) / (out.car + out.heavy);
+	return out;
+}


### PR DESCRIPTION
Closes https://github.com/stijnvanhoey/telraam-bloemekeswijk/issues/10 and https://github.com/stijnvanhoey/telraam-bloemekeswijk/issues/11.

Fetches historic data in the background and computes a ranking of some metrics once ready. A user can visualize the metrics by switching on/off some buttons at the bottom of the map.

Some remaining working points that could be improved in subsequent PRs:

- [x] Speed limits are currently all set to 50. Needs to be revised.
~- [ ] The data is fetched every time the user switches from one page to another (e.g. from blog back to main). This should be avoided as the /traffic_snapshot calls are expensive.~ → To be done in a subsequent PR.
- [x] Switching from one metric to another, without first switching off the first metric, leads to unexpected behavior (no metric selected). I will look into resolving this ASAP.

![220213-functional-metrics](https://user-images.githubusercontent.com/12547760/153775497-a29f9f03-c66a-4752-8901-70215b8aa954.gif)

